### PR TITLE
Source data fix

### DIFF
--- a/src/config/welcomePopupTemplate.ts
+++ b/src/config/welcomePopupTemplate.ts
@@ -4,14 +4,16 @@ const popupContent = `<b>This is a small demo of the React-based GIS web-applica
     <br/>
     Featuring:
         <ul class="list-disc pl-6">
-            <li>Custom default extent</li>
+            <li>Custom default map extent zoomed on Israel</li>
             <li>
+                <span>Capital cities from all over the world using </span>
                 <a class="text-blue-500 underline" href="https://www.arcgis.com/home/item.html?id=d9677f2ef1d547c29fc30e628596f0c0" target="_blank" rel="noopener noreferrer">
-                    World National Capital Cities Feature Layer
+                    World National Capital Cities
                 </a>
+                <span> AGOL item as a source data</span>
             </li>
             <li>
-                Custom popup template for the cities layer
+                Custom popup template for the cities layer displaying the name of the city and the population only
             </li>
         </ul>
     <br/>

--- a/src/hooks/useInitMap.tsx
+++ b/src/hooks/useInitMap.tsx
@@ -16,7 +16,7 @@ const useInitMap = () => {
             // this is a public arcgis online item, so no need to configure portal data or provide credentials
           },
           popupEnabled: true,
-          popupTemplate: citiesPopupTemplate,
+          popupTemplate: citiesPopupTemplate, // configure popup, show city name in the title and population field in the content
         }),
       ],
     });

--- a/src/hooks/useInitMap.tsx
+++ b/src/hooks/useInitMap.tsx
@@ -4,7 +4,6 @@ import MapView from "@arcgis/core/views/MapView.js";
 import { useEffect } from "react";
 import citiesPopupTemplate from "../config/citiesPopupTemplate";
 import welcomePopup from "../config/welcomePopupTemplate";
-import { worldCitiesUrl } from "../services/links";
 
 const useInitMap = () => {
   useEffect(() => {
@@ -12,7 +11,10 @@ const useInitMap = () => {
       basemap: "osm",
       layers: [
         new FeatureLayer({
-          url: worldCitiesUrl,
+          portalItem: {
+            id: "d9677f2ef1d547c29fc30e628596f0c0", // use https://www.arcgis.com/home/item.html?id=d9677f2ef1d547c29fc30e628596f0c0 as source data
+            // this is a public arcgis online item, so no need to configure portal data or provide credentials
+          },
           popupEnabled: true,
           popupTemplate: citiesPopupTemplate,
         }),
@@ -22,7 +24,7 @@ const useInitMap = () => {
     const mapView = new MapView({
       container: "viewDiv",
       map,
-      center: [34.7699, 32.045],
+      center: [34.7699, 32.045], // default map zoomed on Israel
       zoom: 10,
       ui: {
         components: ["attribution"], // remove default top-left zoom widget

--- a/src/services/links.ts
+++ b/src/services/links.ts
@@ -1,2 +1,0 @@
-export const worldCitiesUrl =
-  "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Cities/FeatureServer/0";


### PR DESCRIPTION
Use [AGOL item](https://www.arcgis.com/home/item.html?id=d9677f2ef1d547c29fc30e628596f0c0) with filtered cities as a source data to display capital cities only. (Instead of it's [source Feature Service](https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Cities/FeatureServer/0))